### PR TITLE
missing dependency 'fetch-mock'

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "browserify": "^13.1.0",
     "enzyme": "^2.4.1",
     "expect": "^1.20.2",
+    "fetch-mock": "^5.9.4", 
     "jsdom": "^9.4.1",
     "mocha": "^3.0.0",
     "mocha-multi": "^0.9.0",


### PR DESCRIPTION
added     "fetch-mock": "^5.9.4"